### PR TITLE
Refactor layout partials

### DIFF
--- a/views/companies.handlebars
+++ b/views/companies.handlebars
@@ -1,15 +1,15 @@
-<div class="bg-red-dark pt-6 md:pt-12 pb-10 md:pb-16 px-4">
-  <div class="container mx-auto flex justify-between">
-    <div class="w-full md:w-3/4 lg:w-1/2">
-      <h1 class="text-white">Companies that 💛 software</h1>
-      <p class="mt-4 text-lg text-red-lighter leading-normal">Whether you're a developer hunting for jobs, a company searching for a development agency or a contractor advertising your services, we've got the biggest list of companies building software in Wales.</p>
-
-      <a href="https://docs.google.com/forms/d/e/1FAIpQLSeBgF-wPRtERRqpKKYH6-7cA-VBJ20okEGtVTlC-T-DtC-UFg/viewform?usp=sf_link" target="_blank" class="inline-flex items-center px-4 py-3 leading-none no-underline rounded bg-red hover:bg-white text-white hover:text-red-dark mt-6">Add a company <span class="text-2xl ml-2">✍️</span></a>
-
-      <p class="mt-6 text-red-lighter leading-normal">So far we've added <span class="font-bold">{{companies.length}}</span> companies from <span class="font-bold">{{locations.length}}</span> locations! 🎉</p>
-    </div>
-  </div>
-</div>
+{{#> pageHero }}
+  <h1 class="text-white">Companies that 💛 software</h1>
+  <p class="mt-4 text-lg text-red-lighter leading-normal">
+    Whether you're a developer hunting for jobs, a company searching for a development agency or a contractor advertising your services, we've got the biggest list of companies building software in Wales.
+  </p>
+  <a href="https://docs.google.com/forms/d/e/1FAIpQLSeBgF-wPRtERRqpKKYH6-7cA-VBJ20okEGtVTlC-T-DtC-UFg/viewform?usp=sf_link" target="_blank" class="inline-flex items-center px-4 py-3 leading-none no-underline rounded bg-red hover:bg-white text-white hover:text-red-dark mt-6">
+    Add a company <span class="text-2xl ml-2">✍️</span>
+  </a>
+  <p class="mt-6 text-red-lighter leading-normal">
+    So far we've added <span class="font-bold">{{companies.length}}</span> companies from <span class="font-bold">{{locations.length}}</span> locations! 🎉
+  </p>
+{{/pageHero}}
 
 <div class="py-8 px-4">
   <div class="container mx-auto flex flex-col lg:flex-row">

--- a/views/jobs.handlebars
+++ b/views/jobs.handlebars
@@ -1,20 +1,18 @@
-<div class="bg-red-dark pt-6 md:pt-12 pb-10 md:pb-16 px-4">
-  <div class="container mx-auto">
-    <div class="w-full md:w-3/4 lg:w-1/2">
-      <div class="flex flex-row items-center">
-        <h1 class="text-white">Take control of your career 💪</h1>
-        <div class="ml-4 py-2 px-4 rounded-full bg-red-lighter text-red-dark">Beta</div>
-      </div>
-      <p class="mt-4 text-lg leading-normal text-red-lighter">No recruiters, no nonsense - just awesome jobs for developers.</p>
-      <p class="mt-4 text-lg leading-normal text-red-lighter">
-        We'll get out of the way so that you can take control of your job hunt and apply directly to your favourite companies.
-      </p>
-      <a href="/jobs/add" class="inline-flex items-center px-4 py-3 leading-none no-underline rounded bg-red hover:bg-white text-white hover:text-red-dark mt-6">
-        Add a job <span class="text-2xl ml-2">📝</span>
-      </a>
-    </div>
+{{#> pageHero}}
+  <div class="flex flex-row items-center">
+    <h1 class="text-white">Take control of your career 💪</h1>
+    <div class="ml-4 py-2 px-4 rounded-full bg-red-lighter text-red-dark">Beta</div>
   </div>
-</div>
+  <p class="mt-4 text-lg leading-normal text-red-lighter">
+    No recruiters, no nonsense - just awesome jobs for developers.
+  </p>
+  <p class="mt-4 text-lg leading-normal text-red-lighter">
+    We'll get out of the way so that you can take control of your job hunt and apply directly to your favourite companies.
+  </p>
+  <a href="/jobs/add" class="inline-flex items-center px-4 py-3 leading-none no-underline rounded bg-red hover:bg-white text-white hover:text-red-dark mt-6">
+    Add a job <span class="text-2xl ml-2">📝</span>
+  </a>
+{{/pageHero}}
 
 <div class="py-8 px-4">
   <div class="container mx-auto flex flex-col lg:flex-row">

--- a/views/meetups.handlebars
+++ b/views/meetups.handlebars
@@ -1,62 +1,52 @@
-<div class="bg-red-dark pt-6 md:pt-12 pb-10 md:pb-16 px-4">
-  <div class="container mx-auto">
-    <div class="w-full md:w-3/4 lg:w-1/2">
-      <h1 class="text-white">The best shows in town 🤩</h1>
-      <p class="mt-4 text-lg leading-normal text-red-lighter">
-        Communities grow when like-minded people come together and share their passions.
-      </p>
-      <p class="mt-4 text-lg leading-normal text-red-lighter">
-        Find a meetup that resonates with you and get involved.
-      </p>
-      <a href="https://docs.google.com/forms/d/e/1FAIpQLSewz_bJdPB-Nzt9O9Lia5v--_KLhILBldGjMLe378hZXibI7A/viewform?usp=sf_link" target="_blank" class="inline-flex items-center px-4 py-3 leading-none no-underline rounded bg-red hover:bg-white text-white hover:text-red-dark mt-6">Add a meetup <span class="text-2xl ml-2">✍️</span></a>
-    </div>
-  </div>
-</div>
+{{#> pageHero }}
+  <h1 class="text-white">The best shows in town 🤩</h1>
+  <p class="mt-4 text-lg leading-normal text-red-lighter">
+    Communities grow when like-minded people come together and share their passions.
+  </p>
+  <p class="mt-4 text-lg leading-normal text-red-lighter">
+    Find a meetup that resonates with you and get involved.
+  </p>
+  <a href="https://docs.google.com/forms/d/e/1FAIpQLSewz_bJdPB-Nzt9O9Lia5v--_KLhILBldGjMLe378hZXibI7A/viewform?usp=sf_link" target="_blank" class="inline-flex items-center px-4 py-3 leading-none no-underline rounded bg-red hover:bg-white text-white hover:text-red-dark mt-6">Add a meetup <span class="text-2xl ml-2">✍️</span></a>
+{{/pageHero}}
 
-<div class="pt-4 pb-12 px-4">
-  <div class="container mx-auto flex flex-col lg:flex-row">
-    <div class="w-full">
-      <div id="meetups-list" class="md:flex md:flex-row md:flex-wrap">
-        {{#each meetups}}
-        <div class="md:w-1/3 md:mt-12 md:px-4 lg:mt-16">
-          <div class="bg-white mb-2 p-4 shadow rounded flex items-center md:inline-flex md:flex-col md:w-full md:h-full md:p-6">
-            {{#if this.logoUrl}}
-            <div class="w-16 h-16 flex-shrink-0 rounded bg-center bg-no-repeat bg-contain md:-mt-12 md:shadow md:mb-6 md:bg-white lg:w-24 lg:h-24" style="background-image: url({{this.logoUrl}})"></div>
-            {{else}}
-            <div class="w-16 h-16 flex-shrink-0 rounded flex items-center justify-center md:-mt-12 md:shadow md:bg-white md:mb-6 lg:w-24 lg:h-24">
-              <div class="w-full h-full bg-center bg-no-repeat bg-contain opacity-25" style="background-image: url(/static/logo-mark-black.svg)"></div>
-            </div>
-            {{/if}}
-            <div class="ml-4 flex flex-col sm:flex-row sm:items-center flex-1 md:flex-col md:items-center md:ml-0">
-              <span class="text-grey-darkest font-bold md:text-center sm:flex-1 md:text-lg lg:text-xl">{{this.name}}</span>
-              <div class="flex items-center mt-2 md:mt-6 sm:flex-row-reverse md:flex-row">
-                {{#if this.meetupUrl}}
-                <a href="{{this.meetupUrl}}" target="_blank" class="flex items-center bg-grey-lighter h-8 px-2 rounded-full mr-2 sm:mr-0 sm:ml-2 md:ml-0 md:mr-2">
-                  <img src="/static/meetup.svg" class="h-6" alt="meetup.com logo" />
-                </a>
-                {{/if}}
-                {{#if this.twitterUrl}}
-                <a href="{{this.twitterUrl}}" target="_blank" class="flex items-center bg-grey-lighter h-8 px-2 rounded-full mr-2 sm:mr-0 sm:ml-2 md:ml-0 md:mr-2">
-                  <img src="/static/twitter-solid.svg" class="h-6" alt="twitter logo" />
-                </a>
-                {{/if}}
-                {{#if this.eventbriteUrl}}
-                <a href="{{this.eventbriteUrl}}" target="_blank" class="flex items-center bg-grey-lighter h-8 px-2 rounded-full mr-2 sm:mr-0 sm:ml-2 md:ml-0 md:mr-2">
-                  <img src="/static/eventbrite.svg" class="h-6" alt="eventbrite logo" />
-                </a>
-                {{/if}}
-              </div>
-            </div>
-          </div>
+{{#> gridLayout}}
+  {{#each meetups}}
+  <div class="md:w-1/3 md:mt-12 md:px-4 lg:mt-16">
+    <div class="bg-white mb-2 p-4 shadow rounded flex items-center md:inline-flex md:flex-col md:w-full md:h-full md:p-6">
+      {{#if this.logoUrl}}
+      <div class="w-16 h-16 flex-shrink-0 rounded bg-center bg-no-repeat bg-contain md:-mt-12 md:shadow md:mb-6 md:bg-white lg:w-24 lg:h-24" style="background-image: url({{this.logoUrl}})"></div>
+      {{else}}
+      <div class="w-16 h-16 flex-shrink-0 rounded flex items-center justify-center md:-mt-12 md:shadow md:bg-white md:mb-6 lg:w-24 lg:h-24">
+        <div class="w-full h-full bg-center bg-no-repeat bg-contain opacity-25" style="background-image: url(/static/logo-mark-black.svg)"></div>
+      </div>
+      {{/if}}
+      <div class="ml-4 flex flex-col sm:flex-row sm:items-center flex-1 md:flex-col md:items-center md:ml-0">
+        <span class="text-grey-darkest font-bold md:text-center sm:flex-1 md:text-lg lg:text-xl">{{this.name}}</span>
+        <div class="flex items-center mt-2 md:mt-6 sm:flex-row-reverse md:flex-row">
+          {{#if this.meetupUrl}}
+          <a href="{{this.meetupUrl}}" target="_blank" class="flex items-center bg-grey-lighter h-8 px-2 rounded-full mr-2 sm:mr-0 sm:ml-2 md:ml-0 md:mr-2">
+            <img src="/static/meetup.svg" class="h-6" alt="meetup.com logo" />
+          </a>
+          {{/if}}
+          {{#if this.twitterUrl}}
+          <a href="{{this.twitterUrl}}" target="_blank" class="flex items-center bg-grey-lighter h-8 px-2 rounded-full mr-2 sm:mr-0 sm:ml-2 md:ml-0 md:mr-2">
+            <img src="/static/twitter-solid.svg" class="h-6" alt="twitter logo" />
+          </a>
+          {{/if}}
+          {{#if this.eventbriteUrl}}
+          <a href="{{this.eventbriteUrl}}" target="_blank" class="flex items-center bg-grey-lighter h-8 px-2 rounded-full mr-2 sm:mr-0 sm:ml-2 md:ml-0 md:mr-2">
+            <img src="/static/eventbrite.svg" class="h-6" alt="eventbrite logo" />
+          </a>
+          {{/if}}
         </div>
-
-        {{else}}
-        <div class="my-4 text-lg leading-normal text-grey-dark">No meetups have been added yet 😩</div>
-        {{/each}}
       </div>
     </div>
   </div>
-</div>
+
+  {{else}}
+  <div class="my-4 text-lg leading-normal text-grey-dark">No meetups have been added yet 😩</div>
+  {{/each}}
+{{/gridLayout}}
 
 <script>
     const meetups = {{{ json meetups }}}

--- a/views/meetups.handlebars
+++ b/views/meetups.handlebars
@@ -47,8 +47,3 @@
   <div class="my-4 text-lg leading-normal text-grey-dark">No meetups have been added yet 😩</div>
   {{/each}}
 {{/gridLayout}}
-
-<script>
-    const meetups = {{{ json meetups }}}
-    console.log(meetups);
-</script>

--- a/views/partials/gridLayout.handlebars
+++ b/views/partials/gridLayout.handlebars
@@ -1,0 +1,9 @@
+<div class="pt-4 pb-12 px-4">
+  <div class="container mx-auto flex flex-col lg:flex-row">
+    <div class="w-full">
+      <div id="meetups-list" class="md:flex md:flex-row md:flex-wrap">
+        {{> @partial-block }}
+      </div>
+    </div>
+  </div>
+</div>

--- a/views/partials/pageHero.handlebars
+++ b/views/partials/pageHero.handlebars
@@ -1,0 +1,7 @@
+<div class="bg-red-dark pt-6 md:pt-12 pb-10 md:pb-16 px-4">
+  <div class="container mx-auto">
+    <div class="w-full md:w-3/4 lg:w-1/2">
+      {{> @partial-block }}
+    </div>
+  </div>
+</div>

--- a/views/speakers.handlebars
+++ b/views/speakers.handlebars
@@ -1,19 +1,15 @@
-<div class="bg-red-dark pt-6 md:pt-12 pb-10 md:pb-16 px-4">
-  <div class="container mx-auto">
-    <div class="w-full md:w-3/4 lg:w-1/2">
-      <h1 class="text-white">Psst, we've got what you need ‍👩‍🎤</h1>
-      <p class="mt-4 text-lg leading-normal text-red-lighter">
-        We're building a list of the best speakers to give talks at meetups, conferences or other events.
-      </p>
-      <p class="mt-4 text-lg leading-normal text-red-lighter">
-        If you're a speaker then join the list so that event organisers can reach out to you.
-      </p>
-      <a href="/speakers/add" target="_blank" class="inline-flex items-center px-4 py-3 leading-none no-underline rounded bg-red hover:bg-white text-white hover:text-red-dark mt-6">
-        Join the list <span class="text-2xl ml-2">👋</span>
-      </a>
-    </div>
-  </div>
-</div>
+{{#> pageHero}}
+  <h1 class="text-white">Psst, we've got what you need ‍👩‍🎤</h1>
+  <p class="mt-4 text-lg leading-normal text-red-lighter">
+    We're building a list of the best speakers to give talks at meetups, conferences or other events.
+  </p>
+  <p class="mt-4 text-lg leading-normal text-red-lighter">
+    If you're a speaker then join the list so that event organisers can reach out to you.
+  </p>
+  <a href="/speakers/add" target="_blank" class="inline-flex items-center px-4 py-3 leading-none no-underline rounded bg-red hover:bg-white text-white hover:text-red-dark mt-6">
+    Join the list <span class="text-2xl ml-2">👋</span>
+  </a>
+{{/pageHero}}
 
 <div class="py-8 px-4">
   <div class="container mx-auto flex flex-col lg:flex-row">


### PR DESCRIPTION
There's a lot of duplicate code across the different view templates so I've begun refactoring shared code into the following partials:

* `pageHero.handlebars` - container with a red background used at the top of each page (except `/about`)
* `gridLayout.handlebars` - container with flex rules for the grid layout used on the `/meetups` page.

This doesn't include some of the child elements such as grid cards, so I might follow up with another PR to refactor those elements as partials as well.